### PR TITLE
Fix repo references

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sharedstreets/sharedstreets-js.git"
+    "url": "git+https://github.com/sharedstreets/sharedstreets-pbf.git"
   },
   "keywords": [
     "sharedstreets",
@@ -34,9 +34,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sharedstreets/sharedstreets-js/issues"
+    "url": "https://github.com/sharedstreets/sharedstreets-pbf/issues"
   },
-  "homepage": "https://github.com/sharedstreets/sharedstreets-js#readme",
+  "homepage": "https://github.com/sharedstreets/sharedstreets-pbf#readme",
   "devDependencies": {
     "@types/node": "*",
     "benchmark": "*",


### PR DESCRIPTION
I think these should be pointing to pbf instead of js?

Pretty sure this will change the repo shown on npm:
![image](https://user-images.githubusercontent.com/875591/36004886-c53fd158-0ce9-11e8-986d-7307c5f33981.png)
